### PR TITLE
Allow existing dir and don't append key to dir

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,13 +46,9 @@ module.exports = function (datPath, downloadDest, cb) {
     function downloadDir (dirname, cb) {
       debug('downloading dir', dirname)
       var dest = path.join(downloadDest, dirname)
-      fs.stat(dest, function (_, stat) {
-        // throw if dest exists
-        if (stat && stat.isDirectory()) return cb(new Error('Destination path exists:' + dest))
-        mkdirp(dest, function (err) {
-          if (err) return cb(err)
-          mirror({fs: archive, name: dirname}, dest, cb)
-        })
+      mkdirp(dest, function (err) {
+        if (err) return cb(err)
+        mirror({fs: archive, name: dirname}, dest, cb)
       })
     }
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function (datPath, downloadDest, cb) {
   if (datPath.indexOf('//') > -1) datPath = datPath.split('//')[1]
   var key = 'dat://' + datPath.split('/')[0]
   var entryPath = '/' + datPath.split('/').slice(1).join('/')
-  if (entryPath === '/') downloadDest = path.join(downloadDest, datPath.split('/')[0])
+  // if (entryPath === '/') downloadDest = path.join(downloadDest, datPath.split('/')[0])
   debug('downloadDir', downloadDest)
   debug('dat key', key)
   debug('dat path', entryPath)

--- a/index.js
+++ b/index.js
@@ -48,8 +48,18 @@ module.exports = function (datPath, downloadDest, cb) {
       var dest = path.join(downloadDest, dirname)
       mkdirp(dest, function (err) {
         if (err) return cb(err)
-        mirror({fs: archive, name: dirname}, dest, cb)
+        mirror({fs: archive, name: dirname}, dest, {equals: equals}, cb)
       })
+
+      function equals (src, dst, cb) {
+        console.log('src.name, dst.name', src.name, dst.name)
+        console.log('dir', src.stat.isDirectory(), dst.stat.isDirectory())
+        if (src.stat.isDirectory()) return cb(null, true)
+        console.log('not directory')
+        if (src.stat.size !== dst.stat.size) return cb(null, false)
+        if (src.stat.mtime.getTime() > dst.stat.mtime.getTime()) return cb(null, false)
+        cb(null, true)
+      }
     }
 
     function downloadFile (file, cb) {

--- a/test/index.js
+++ b/test/index.js
@@ -15,8 +15,7 @@ test('Download full dat', function (t) {
   tmp(function (_, dir, cleanup) {
     downloadDat(testdats.fullDat, dir, function (err) {
       t.error(err, 'no error')
-      var key = testdats.fullDat.split('//')[1]
-      fs.stat(path.join(dir, key), function (err, stat) {
+      fs.stat(dir, function (err, stat) {
         t.error(err, 'no error')
         t.ok(stat.isDirectory(), 'directory exists')
         cleanup(function () {
@@ -31,8 +30,7 @@ test('Download full dat 2', function (t) {
   tmp(function (_, dir, cleanup) {
     downloadDat(testdats.fullDat2, dir, function (err) {
       t.error(err, 'no error')
-      var key = testdats.fullDat.split('//')[1]
-      fs.stat(path.join(dir, key), function (err, stat) {
+      fs.stat(dir, function (err, stat) {
         t.error(err, 'no error')
         t.ok(stat.isDirectory(), 'directory exists')
         cleanup(function () {

--- a/test/index.js
+++ b/test/index.js
@@ -26,10 +26,13 @@ test('Download full dat', function (t) {
   })
 })
 
-test('Download full dat 2', function (t) {
+test.only('Download full dat 2', function (t) {
   tmp(function (_, dir, cleanup) {
+    // write an existing file into dest
+    fs.writeFileSync(dir + '/extra.txt', 'extra')
     downloadDat(testdats.fullDat2, dir, function (err) {
       t.error(err, 'no error')
+      t.strictEqual(fs.readFileSync(dir + '/extra.txt', 'utf8'), 'extra', 'does not remove extra file')
       fs.stat(dir, function (err, stat) {
         t.error(err, 'no error')
         t.ok(stat.isDirectory(), 'directory exists')


### PR DESCRIPTION
Been using this in different ways, it works great, thanks for putting it up. A couple interrelated things I wanted to change for myself, maybe you'd agree:
- dont throw an error if the directory already exists to allow for re-downloading a dat. Any downsides to this?
- dont append an extra directory level of the dat key. For my uses, this was important. Eg. I want to download a dat to `/tmp/x`, not `/tmp/x/datKey-xyz`